### PR TITLE
Forward the caller's config; konserve 0.9.369

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         io.replikativ/clj-rocksdb {:mvn/version "0.1.33"}
         com.taoensso/timbre {:mvn/version "6.6.1"}
         com.taoensso/nippy {:mvn/version "3.4.2"}
-        org.replikativ/konserve {:mvn/version "0.9.342"}
+        org.replikativ/konserve {:mvn/version "0.9.369"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}}
  :aliases {:dev {:extra-paths ["test"]}
            :test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}

--- a/src/konserve_rocksdb/core.clj
+++ b/src/konserve_rocksdb/core.clj
@@ -4,8 +4,6 @@
             [konserve.impl.storage-layout :refer [PBackingStore PBackingBlob PBackingLock
                                                   PMultiWriteBackingStore PMultiReadBackingStore
                                                   -delete-store]]
-            [konserve.compressor :refer [null-compressor]]
-            [konserve.encryptor :refer [null-encryptor]]
             [konserve.utils :refer [async+sync *default-sync-translation*]]
             [konserve.store :as store]
             [superv.async :refer [go-try-]]
@@ -177,19 +175,32 @@
                              {}
                              store-keys)))))))
 
-(defn connect-rocksdb-store [path & {:keys [opts]}]
+(defn connect-rocksdb-store
+  "Connect a konserve store backed by RocksDB.
+
+  Everything except `:opts` and `:config` is forwarded to
+  `connect-default-store`, so `:default-serializer`, the handler maps and
+  `:buffer-size` all work. They did not before: this built a LITERAL config
+  map and destructured only `:opts`, so a caller asking for a different
+  serializer got Fressian and was told nothing.
+
+  It also passed `:compressor null-compressor` and `:encryptor
+  null-encryptor`, which `connect-default-store` never reads -- it takes both
+  from `(get-in config [:compressor :type])`. Dead keys that made a top-level
+  spelling look supported; removed."
+  [path & {:keys [opts config] :as params}]
   (let [complete-opts (merge {:sync? true} opts)
         backing (RocksDBStore. path (atom nil))
-        config {:path               path
-                :opts               complete-opts
-                :config             {:sync-blob? true
-                                     :in-place? true
-                                     :lock-blob? true}
-                :default-serializer :FressianSerializer
-                :compressor         null-compressor
-                :encryptor          null-encryptor
-                :buffer-size        (* 1024 1024)}]
-    (connect-default-store backing config)))
+        store-config (merge {:default-serializer :FressianSerializer
+                             :buffer-size        (* 1024 1024)}
+                            (dissoc params :opts :config)
+                            {:path   path
+                             :opts   complete-opts
+                             :config (merge {:sync-blob? true
+                                             :in-place? true
+                                             :lock-blob? true}
+                                            config)})]
+    (connect-default-store backing store-config)))
 
 (defn delete-rocksdb-store [path & {:keys [opts]}]
   (let [complete-opts (merge {:sync? true} opts)

--- a/test/konserve_rocksdb/core_test.clj
+++ b/test/konserve_rocksdb/core_test.clj
@@ -1,5 +1,6 @@
 (ns konserve-rocksdb.core-test
-  (:require [clojure.test :refer [deftest testing]]
+  (:require [clojure.test :refer [deftest testing is]]
+            [konserve.core :as k]
             [clojure.core.async :refer [<!!]]
             [konserve.compliance-test :refer [compliance-test]]
             [konserve-rocksdb.core :refer [connect-rocksdb-store
@@ -23,3 +24,28 @@
       (compliance-test store))
     (release-rocksdb store)
     (<!! (delete-rocksdb-store path2 :opts {:sync? false}))))
+
+(deftest config-reaches-connect-default-store
+  (testing "this built a LITERAL config map and destructured only `:opts`, so
+            everything else a caller passed was discarded -- a request for a
+            different serializer produced Fressian and said nothing. It also
+            shipped `:compressor null-compressor` and `:encryptor
+            null-encryptor`, which `connect-default-store` never reads.
+
+            Asserted through a real round trip, because the serializer that
+            matters is the one that actually wrote the bytes."
+    (let [mk (fn [d & args]
+               (try (delete-rocksdb-store d) (catch Exception _ nil))
+               (let [s (apply connect-rocksdb-store d args)
+                     v {:a (vec (range 50)) :b "x"}]
+                 (k/assoc s "c" v {:sync? true})
+                 [(:default-serializer s) (= v (k/get s "c" nil {:sync? true}))]))]
+      (testing "the default is unchanged"
+        (is (= [:FressianSerializer true] (mk "/tmp/krdb-test-default"))))
+      (testing "the old top-level spelling reaches the store"
+        (is (= [:BoringSerializer true]
+               (mk "/tmp/krdb-test-old" :default-serializer :BoringSerializer))))
+      (testing "and so does :config :encoding"
+        (is (= [:BoringSerializer true]
+               (mk "/tmp/krdb-test-enc"
+                   :config {:encoding {:serializer :BoringSerializer}})))))))


### PR DESCRIPTION
Bumps konserve to 0.9.369 and makes this backend actually take a config.

`connect-rocksdb-store` built a **literal** config map and destructured only `:opts`, so everything else a caller passed was discarded. Asking for a different serializer produced Fressian and said nothing — which meant konserve's boring serializer was unreachable here.

It also passed `:compressor null-compressor` / `:encryptor null-encryptor`, which `connect-default-store` has never read (it takes both from `(get-in config [:compressor :type])`). Dead keys that made a top-level spelling look supported. Removed.

Now merges `params`, so `:default-serializer`, the handler maps and `:buffer-size` all reach the store, and 0.9.369's `:config {:encoding {...}}` works.

The test asserts through a **real round trip** rather than on the store record, because the serializer that matters is the one that wrote the bytes.

3 tests, 267 assertions green; format clean.