### PR TITLE
Conditional writes: one transaction covering the metadata and the value

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,10 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-        io.replikativ/clj-rocksdb {:mvn/version "0.1.33"}
+        ;; MUST NOT MERGE as a local root — revert to the released
+        ;; org.replikativ/clj-rocksdb once replikativ/clj-rocksdb#2 is on Clojars.
+        org.replikativ/clj-rocksdb {:local/root "../clj-rocksdb"}
         com.taoensso/nippy {:mvn/version "3.4.2"}
-        org.replikativ/konserve {:mvn/version "0.9.369"}
+        org.replikativ/konserve {:mvn/version "0.9.376"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}}
  :aliases {:dev {:extra-paths ["test"]}
            :test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,6 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-        ;; MUST NOT MERGE as a local root — revert to the released
-        ;; org.replikativ/clj-rocksdb once replikativ/clj-rocksdb#2 is on Clojars.
-        org.replikativ/clj-rocksdb {:local/root "../clj-rocksdb"}
+        org.replikativ/clj-rocksdb {:mvn/version "0.1.36"}
         com.taoensso/nippy {:mvn/version "3.4.2"}
         org.replikativ/konserve {:mvn/version "0.9.376"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}}

--- a/src/konserve_rocksdb/core.clj
+++ b/src/konserve_rocksdb/core.clj
@@ -1,6 +1,7 @@
 (ns konserve-rocksdb.core
   "Address globally aggregated immutable key-value stores(s)."
   (:require [konserve.impl.defaults :refer [connect-default-store]]
+            [konserve.protocols :as protocols]
             [konserve.impl.storage-layout :refer [PBackingStore PBackingBlob PBackingLock
                                                   PMultiWriteBackingStore PMultiReadBackingStore
                                                   -delete-store]]
@@ -18,21 +19,72 @@
   {:key-encoder nippy/freeze
    :key-decoder nippy/thaw
    :val-encoder nippy/freeze
-   :val-decoder nippy/thaw})
+   :val-decoder nippy/thaw
+   ;; Opens an OptimisticTransactionDB, which is what `compare-and-put!` needs to
+   ;; fence a write. It costs nothing otherwise — an OptimisticTransactionDB IS a
+   ;; RocksDB, so every other operation is unchanged.
+   :transactional? true
+   :create-if-missing? true})
 
 (extend-protocol PBackingLock
   Boolean
   (-release [_ env]
     (if (:sync? env) nil (go-try- nil))))
 
-(defrecord RocksDBKV [db key data]
+(defrecord RocksDBKV [store db key data]
   PBackingBlob
   (-sync [_ env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- (let [{:keys [header meta value]} @data]
-                           (when (and header meta value)
-                             (rocksdb/put db (str key ".meta") (dissoc @data :value))
-                             (rocksdb/put db key (:value @data)))))))
+                (go-try-
+                 (let [{:keys [header meta value]} @data
+                       expected-revision (:expected-revision env)
+                       meta-key (str key ".meta")
+                       new-meta (dissoc @data :value)]
+                   (when (and header meta value)
+                     (if expected-revision
+                       ;; FENCED. konserve has already compared the revision it read
+                       ;; against the caller's; the transaction closes the window
+                       ;; BETWEEN that read and this write, which is the half no
+                       ;; counter can do. Both together are the compare-and-set.
+                       ;;
+                       ;; The comparison is on the META entry, because that is where
+                       ;; the revision lives — and both entries are written inside
+                       ;; the one transaction that carries it, so a fenced write
+                       ;; cannot leave the metadata ahead of the value.
+                       ;;
+                       ;; What was read is remembered by `-read-header`, since
+                       ;; `-sync` runs on a DIFFERENT blob record than the read did.
+                       ;; No entry means no read happened, which for a fenced write
+                       ;; is create-if-absent.
+                       ;;
+                       ;; THIS ASSUMES ONE IN-FLIGHT FENCED WRITE PER KEY PER
+                       ;; BACKING, and that holds because konserve's `go-locked`
+                       ;; serialises per key on a store instance and RocksDB refuses
+                       ;; a second open of the same directory, so there is exactly
+                       ;; one such instance. Break either and the entry is wrong
+                       ;; rather than missing: a second reader would overwrite it,
+                       ;; and the first writer would then fence against a revision
+                       ;; it never read. Measured, by forcing that state with
+                       ;; independent lock registries over one backing: 55 of 60
+                       ;; increments survived. The assumption is doing real work, so
+                       ;; it is written down rather than left implicit.
+                       (let [cache (:read-cache store)
+                             expected (get @cache meta-key rocksdb/absent)]
+                         (try
+                           (when-not (rocksdb/compare-and-put!
+                                      db meta-key expected
+                                      {meta-key new-meta key (:value @data)})
+                             (throw (ex-info (str "Conditional write rejected: the stored metadata is "
+                                                  "not the one this write was derived from.")
+                                             {:type :konserve/revision-mismatch
+                                              :key key
+                                              :expected expected-revision})))
+                           (finally
+                             ;; Whatever happened, this read is spent.
+                             (swap! cache dissoc meta-key))))
+                       (do
+                         (rocksdb/put db meta-key new-meta)
+                         (rocksdb/put db key (:value @data)))))))))
   (-close [_ env]
     (if (:sync? env) (reset! data {}) (go-try- (reset! data {}))))
   (-get-lock [_ env]
@@ -43,6 +95,13 @@
                            header
                            (let [meta (rocksdb/get db (str key ".meta"))]
                              (swap! data merge meta)
+                             ;; Remember it for a fenced `-sync`, and only for one.
+                             ;; The read preceding a conditional write carries
+                             ;; `:expected-revision` in its env, so we can tell —
+                             ;; caching on every read would hold the metadata of
+                             ;; every key a store ever touched.
+                             (when (:expected-revision env)
+                               (swap! (:read-cache store) assoc (str key ".meta") meta))
                              (:header meta))))))
   (-read-meta [_ _meta-size env]
     (async+sync (:sync? env) *default-sync-translation*
@@ -82,11 +141,23 @@
                 (go-try-
                  (swap! data assoc :value blob)))))
 
-(defrecord RocksDBStore [path db]
+(defrecord RocksDBStore [path db read-cache]
+  ;; RocksDB evaluates the comparison — `compare-and-put!` runs it inside an
+  ;; optimistic transaction whose commit fails if anyone wrote the compared key in
+  ;; between. konserve adds no mechanism of its own: no sidecar, no lock.
+  protocols/PSelfConditionalWrite
+
+  protocols/PConditionalWrite
+  ;; `:process`, and no further. RocksDB takes an exclusive OS lock on the database
+  ;; directory, so a second process cannot open it at all — the transaction is
+  ;; atomic against every thread that can reach this database, and there is nobody
+  ;; else by construction.
+  (-conditional-write-domain [_] :process)
+
   PBackingStore
-  (-create-blob [_ store-key env]
+  (-create-blob [this store-key env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- (RocksDBKV. @db store-key (atom {})))))
+                (go-try- (RocksDBKV. this @db store-key (atom {})))))
   (-delete-blob [_ store-key env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try- (rocksdb/delete @db store-key))))
@@ -154,7 +225,7 @@
                      (into {} (map (fn [k] [k (contains? existing-keys k)]) store-keys)))))))
 
   PMultiReadBackingStore
-  (-multi-read-blobs [_ store-keys env]
+  (-multi-read-blobs [this store-keys env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try-
                  (if (empty? store-keys)
@@ -168,7 +239,7 @@
                                      meta-data (get results (str store-key ".meta"))]
                                  (if (and value meta-data)
                                    ;; Create blob with pre-populated data atom
-                                   (let [blob (RocksDBKV. @db store-key
+                                   (let [blob (RocksDBKV. this @db store-key
                                                           (atom (assoc meta-data :value value)))]
                                      (assoc acc store-key blob))
                                    acc)))
@@ -190,7 +261,7 @@
   spelling look supported; removed."
   [path & {:keys [opts config] :as params}]
   (let [complete-opts (merge {:sync? true} opts)
-        backing (RocksDBStore. path (atom nil))
+        backing (RocksDBStore. path (atom nil) (atom {}))
         store-config (merge {:default-serializer :FressianSerializer
                              :buffer-size        (* 1024 1024)}
                             (dissoc params :opts :config)
@@ -204,7 +275,7 @@
 
 (defn delete-rocksdb-store [path & {:keys [opts]}]
   (let [complete-opts (merge {:sync? true} opts)
-        backing (RocksDBStore. path (atom nil))]
+        backing (RocksDBStore. path (atom nil) (atom {}))]
     (-delete-store backing complete-opts)))
 
 (defn release-rocksdb [store]

--- a/test/konserve_rocksdb/core_test.clj
+++ b/test/konserve_rocksdb/core_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [deftest testing is]]
             [konserve.core :as k]
             [clojure.core.async :refer [<!!]]
-            [konserve.compliance-test :refer [compliance-test]]
+            [konserve.compliance-test :refer [compliance-test
+                                              conditional-write-compliance-test]]
             [konserve-rocksdb.core :refer [connect-rocksdb-store
                                            delete-rocksdb-store
                                            release-rocksdb]]))
@@ -49,3 +50,79 @@
         (is (= [:BoringSerializer true]
                (mk "/tmp/krdb-test-enc"
                    :config {:encoding {:serializer :BoringSerializer}})))))))
+
+(deftest rocksdb-conditional-write-test
+  (testing "the `:expected-revision` contract.
+
+            The comparison happens inside an optimistic transaction, and both the
+            metadata entry and the value entry are written inside it — this backend
+            stores a blob as two RocksDB keys, so a fenced write has to cover both
+            or it could leave the metadata ahead of the value."
+    (let [path "/tmp/rocks-db-cas-test"
+          _ (delete-rocksdb-store path :opts {:sync? true})
+          store (connect-rocksdb-store path :opts {:sync? true})]
+      (try
+        (is (= :process (k/conditional-write-domain store))
+            "RocksDB holds an exclusive OS lock on the directory, so no other process can reach it")
+        (conditional-write-compliance-test store)
+        (finally
+          (release-rocksdb store)
+          (delete-rocksdb-store path :opts {:sync? true}))))))
+
+(deftest rocksdb-concurrent-fenced-counter-test
+  (testing "concurrent increments converge and none is lost.
+
+            READ WHAT THIS DOES AND DOES NOT SHOW. The threads share one store
+            instance, because that is the only shape reachable here: RocksDB takes
+            an exclusive OS lock on the directory, so a second process cannot open
+            it and `connect-rocksdb-store` cannot be called twice.
+
+            konserve's `go-locked` therefore serialises these threads per key, and
+            that — not the storage-level fence — is what makes them converge.
+            Verified: with `compare-and-put!` replaced by two plain puts, this test
+            stays green. It is a test of the whole stack behaving correctly under
+            threads, not evidence that the fence works.
+
+            Driving it the other way, with independent lock registries over one
+            backing, does fail (55 of 60) — but that state cannot be produced
+            through the public API, and it fails for a reason documented at the
+            read cache in core.clj rather than because the fence is wrong.
+
+            What the fence buys here is written in that comment too: the metadata
+            entry and the value entry land in ONE transaction, where they used to
+            be two puts that could tear."
+    (let [path "/tmp/rocks-db-conc-test"
+          _ (delete-rocksdb-store path :opts {:sync? true})
+          store (connect-rocksdb-store path :opts {:sync? true})
+          threads 4 per-thread 15
+          expected (* threads per-thread)
+          conflicts (atom 0)
+          unexpected (atom [])]
+      (try
+        (k/assoc-in store [:counter] 0 {:sync? true})
+        (let [fs (doall
+                  (for [_ (range threads)]
+                    (let [store store]
+                     (future
+                      (dotimes [_ per-thread]
+                        (loop [tries 0]
+                          (let [rev (k/revision store :counter {:sync? true})
+                                r (try (k/update-in store [:counter] (fnil inc 0)
+                                                    {:sync? true :expected-revision rev})
+                                       ::ok
+                                       (catch Exception e (or (:type (ex-data e)) ::other)))]
+                            (cond
+                              (= ::ok r) :done
+                              (= :konserve/revision-mismatch r)
+                              (do (swap! conflicts inc)
+                                  (if (< tries 1000)
+                                    (recur (inc tries))
+                                    (swap! unexpected conj :retries-exhausted)))
+                              :else (swap! unexpected conj r)))))))))]
+          (doseq [f fs] @f))
+        (is (empty? @unexpected) (str "unexpected failures: " (pr-str @unexpected)))
+        (is (= expected (k/get-in store [:counter] nil {:sync? true}))
+            "every increment must survive")
+        (finally
+          (release-rocksdb store)
+          (delete-rocksdb-store path :opts {:sync? true}))))))

--- a/test/konserve_rocksdb/core_test.clj
+++ b/test/konserve_rocksdb/core_test.clj
@@ -103,22 +103,22 @@
         (let [fs (doall
                   (for [_ (range threads)]
                     (let [store store]
-                     (future
-                      (dotimes [_ per-thread]
-                        (loop [tries 0]
-                          (let [rev (k/revision store :counter {:sync? true})
-                                r (try (k/update-in store [:counter] (fnil inc 0)
-                                                    {:sync? true :expected-revision rev})
-                                       ::ok
-                                       (catch Exception e (or (:type (ex-data e)) ::other)))]
-                            (cond
-                              (= ::ok r) :done
-                              (= :konserve/revision-mismatch r)
-                              (do (swap! conflicts inc)
-                                  (if (< tries 1000)
-                                    (recur (inc tries))
-                                    (swap! unexpected conj :retries-exhausted)))
-                              :else (swap! unexpected conj r)))))))))]
+                      (future
+                        (dotimes [_ per-thread]
+                          (loop [tries 0]
+                            (let [rev (k/revision store :counter {:sync? true})
+                                  r (try (k/update-in store [:counter] (fnil inc 0)
+                                                      {:sync? true :expected-revision rev})
+                                         ::ok
+                                         (catch Exception e (or (:type (ex-data e)) ::other)))]
+                              (cond
+                                (= ::ok r) :done
+                                (= :konserve/revision-mismatch r)
+                                (do (swap! conflicts inc)
+                                    (if (< tries 1000)
+                                      (recur (inc tries))
+                                      (swap! unexpected conj :retries-exhausted)))
+                                :else (swap! unexpected conj r)))))))))]
           (doseq [f fs] @f))
         (is (empty? @unexpected) (str "unexpected failures: " (pr-str @unexpected)))
         (is (= expected (k/get-in store [:counter] nil {:sync? true}))


### PR DESCRIPTION
Implements konserve's conditional-write contract ([konserve#171](https://github.com/replikativ/konserve/pull/171)) for RocksDB, the last
of the backends in [konserve#172](https://github.com/replikativ/konserve/issues/172) apart from JDBC.

Uses `compare-and-put!` from clj-rocksdb 0.1.36 ([#1](https://github.com/replikativ/clj-rocksdb/pull/1), [#2](https://github.com/replikativ/clj-rocksdb/pull/2)) — note that artifact
also moved from `io.replikativ` to `org.replikativ`, matching konserve.

A blob here is **two RocksDB keys**, `<key>.meta` and `<key>`, previously written as two
separate puts. The fence compares the metadata entry, and both entries are written inside
the transaction that carries it — so a fenced write can no longer leave the metadata
ahead of the value. That torn-write window predates this work and is closed for fenced
writes as a side effect.

**`:process`**, and no further: RocksDB takes an exclusive OS lock on the database
directory, so no second process can open it and there is nobody else to be atomic
against. `PSelfConditionalWrite`, because the transaction is RocksDB's own — konserve
adds no sidecar and no lock.

## What the concurrency test shows, and what it does not

The threads share one store instance, because that is the only shape reachable:
`connect-rocksdb-store` cannot be called twice against one directory. konserve's
`go-locked` therefore serialises them per key, and **that** is what makes them converge —
with `compare-and-put!` replaced by two plain puts, the test stays green. It exercises the
stack under threads; it is not evidence that the fence works.

Driving it the other way, with independent lock registries over one backing, loses 5 of
60 increments. That state cannot be produced through the public API, and it fails for a
reason now documented at the read cache: the cache is keyed by store-key, so a second
in-flight read on the same key overwrites the first writer's expectation and it fences
against a revision it never read. The invariant that makes this safe — one in-flight
fenced write per key per backing, from `go-locked` plus RocksDB's exclusive open — is
doing real work, so it is written down rather than left implicit.

## Found on the way

clj-rocksdb's `create-db` had **never applied any of its options** (`directory` sat inside
the `let` passed to `open`, selecting the one-argument overload), and fixing that exposed
a **use-after-free**: `RocksDB/open` does not take ownership of the `Options`, so the
first version aborted the JVM with `pure virtual method called` part-way through this
suite. Both are handled in clj-rocksdb #1/#2; `option-setters` is still broken
(`.setArenablockSize` does not exist) and is reported there rather than fixed, since
enabling the options is a behaviour change for every caller.

5 tests, 326 assertions, against the published jar.